### PR TITLE
Don't log counter when exception raised

### DIFF
--- a/lib/harness/instrumentation.rb
+++ b/lib/harness/instrumentation.rb
@@ -2,5 +2,7 @@ ActiveSupport::Notifications.subscribe %r{.+} do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
 
   Harness::Gauge.from_event(event).log if event.payload[:gauge]
-  Harness::Counter.from_event(event).log if event.payload[:counter]
+  if event.payload[:counter] && !event.payload[:exception]
+    Harness::Counter.from_event(event).log
+  end
 end

--- a/lib/harness/instrumentation.rb
+++ b/lib/harness/instrumentation.rb
@@ -1,8 +1,8 @@
 ActiveSupport::Notifications.subscribe %r{.+} do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
 
-  Harness::Gauge.from_event(event).log if event.payload[:gauge]
-  if event.payload[:counter] && !event.payload[:exception]
-    Harness::Counter.from_event(event).log
+  unless event.payload[:exception]
+    Harness::Gauge.from_event(event).log if event.payload[:gauge]
+    Harness::Counter.from_event(event).log if event.payload[:counter]
   end
 end

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -37,7 +37,7 @@ class ActiveSupportTestCase < IntegrationTest
     assert_counter_not_logged "counter_test.harness"
   end
 
-  def test_does_log_gauge_on_exception
+  def test_does_not_log_gauge_on_exception
     begin
       ActiveSupport::Notifications.instrument "gauge_test.harness", :gauge => true do |args|
         raise
@@ -45,6 +45,6 @@ class ActiveSupportTestCase < IntegrationTest
     rescue
     end
 
-    assert_gauge_logged "gauge_test.harness"
+    assert_gauge_not_logged "gauge_test.harness"
   end
 end

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -28,23 +28,23 @@ class ActiveSupportTestCase < IntegrationTest
 
   def test_does_not_log_counter_on_exception
     begin
-      ActiveSupport::Notifications.instrument "test.harness", :gauge => { :id => "test-gauge" }, :counter => {:id => 'test-counter', :value => 5 } do |args|
+      ActiveSupport::Notifications.instrument "counter_test.harness", :counter => true do |args|
         raise
       end
     rescue
     end
 
-    assert_counter_not_logged "test-counter"
+    assert_counter_not_logged "counter_test.harness"
   end
 
   def test_does_log_gauge_on_exception
     begin
-      ActiveSupport::Notifications.instrument "test.harness", :gauge => { :id => "test-gauge" }, :counter => {:id => 'test-counter', :value => 5 } do |args|
+      ActiveSupport::Notifications.instrument "gauge_test.harness", :gauge => true do |args|
         raise
       end
     rescue
     end
 
-    assert_gauge_logged "test-gauge"
+    assert_gauge_logged "gauge_test.harness"
   end
 end

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -25,4 +25,26 @@ class ActiveSupportTestCase < IntegrationTest
     assert_counter_logged "test-counter"
     assert_gauge_logged "test-gauge"
   end
+
+  def test_does_not_log_counter_on_exception
+    begin
+      ActiveSupport::Notifications.instrument "test.harness", :gauge => { :id => "test-gauge" }, :counter => {:id => 'test-counter', :value => 5 } do |args|
+        raise
+      end
+    rescue
+    end
+
+    assert_counter_not_logged "test-counter"
+  end
+
+  def test_does_log_gauge_on_exception
+    begin
+      ActiveSupport::Notifications.instrument "test.harness", :gauge => { :id => "test-gauge" }, :counter => {:id => 'test-counter', :value => 5 } do |args|
+        raise
+      end
+    rescue
+    end
+
+    assert_gauge_logged "test-gauge"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,10 @@ class IntegrationTest < MiniTest::Unit::TestCase
     refute_empty counters.select {|c| c.name = name }, "Expected #{counters.inspect} to contain a #{name} result"
   end
 
+  def assert_counter_not_logged(name)
+    assert_empty counters.select {|c| c.name = name }, "No counter expected to be logged"
+  end
+
   def gauges
     Harness::MemoryAdapter.gauges
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,10 @@ class IntegrationTest < MiniTest::Unit::TestCase
     refute_empty counters.select {|c| c.name = name }, "Expected #{counters.inspect} to contain a #{name} result"
   end
 
+  def assert_gauge_not_logged(name)
+    assert_empty gauges.select {|g| g.name = name }, "No gauge expected to be logged"
+  end
+
   def assert_counter_not_logged(name)
     assert_empty counters.select {|c| c.name = name }, "No counter expected to be logged"
   end


### PR DESCRIPTION
This pull request makes stuff like the following example work as expected:

``` ruby
def create
  ActiveSuppport::Notifications.instrument 'count.users', counter: true do
    User.create! params[:user]
  end
rescue ActiveRecord::RecordInvalid
  render :new
end
```

I'm not quite sure if gauges should still be tracked, though.
