### PR TITLE
Allow a gauge's value to be specified in the event payload

### DIFF
--- a/lib/harness/gauge.rb
+++ b/lib/harness/gauge.rb
@@ -15,7 +15,7 @@ module Harness
       end
 
       gauge.id ||= event.name
-      gauge.value = event.duration
+      gauge.value ||= event.duration
 
       gauge
     end

--- a/test/unit/gauge_test.rb
+++ b/test/unit/gauge_test.rb
@@ -65,6 +65,16 @@ class GaugeTest < MiniTest::Unit::TestCase
     assert_equal 'foo', gauge.id
   end
 
+  def test_sets_value_from_payload_if_number
+    base = Time.now
+
+    event = ActiveSupport::Notifications::Event.new "name", base - 1, Time.now, nil, :gauge => {value: 42}
+
+    gauge = Harness::Gauge.from_event event
+
+    assert_equal 42, gauge.value
+  end
+
   def test_initializes_time_if_not_set
     gauge = Harness::Gauge.new
 


### PR DESCRIPTION
Gauges are great for times, but they are also useful for other variable numeric values. This PR allows the you to specify a value when creating a gauge, which it will use instead of the default event.duration.
