### PR TITLE
Documentation and spelling cleanup

### DIFF
--- a/lib/harness.rb
+++ b/lib/harness.rb
@@ -90,7 +90,7 @@ require 'harness/instrumentation'
 
 require 'harness/job'
 
-require 'harness/queues/syncronous_queue'
+require 'harness/queues/synchronous_queue'
 
 require 'harness/adapters/librato_adapter'
 require 'harness/adapters/memory_adapter'

--- a/lib/harness/queues/synchronous_queue.rb
+++ b/lib/harness/queues/synchronous_queue.rb
@@ -1,5 +1,5 @@
 module Harness
-  class SyncronousQueue
+  class SynchronousQueue
     def push(measurement)
       begin
         Harness::Job.new.log(measurement)
@@ -15,4 +15,6 @@ module Harness
       Harness.logger
     end
   end
+  # Preserve previous spelling for backward compatibility
+  SyncronousQueue = SynchronousQueue
 end

--- a/lib/harness/railtie.rb
+++ b/lib/harness/railtie.rb
@@ -12,8 +12,8 @@ module Harness
     # Custom instrumentation can be turned on as follows
     # See files in lib/harness/integration for available integrations
     #
-    # config.harness.insturment.sidekiq = true
-    # config.harness.insturment.active_model_serializers = true
+    # config.harness.instrument.sidekiq = true
+    # config.harness.instrument.active_model_serializers = true
 
     rake_tasks do
       load "harness/tasks.rake"
@@ -40,7 +40,7 @@ module Harness
     end
 
     initializer "harness.queue" do
-      Harness.config.queue = Harness::SyncronousQueue
+      Harness.config.queue = Harness::SynchronousQueue
     end
 
     initializer "harness.queue.production" do |app|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,7 @@ Harness.redis = Redis::Namespace.new 'harness-test', :redis => Redis.connect(:ho
 class IntegrationTest < MiniTest::Unit::TestCase
   def setup
     Harness.config.adapter = :memory
-    Harness.config.queue = :syncronous
+    Harness.config.queue = :synchronous
 
     gauges.clear ; counters.clear
     redis.flushall
@@ -58,7 +58,7 @@ class IntegrationTest < MiniTest::Unit::TestCase
   end
 
   def instrument(name, data = {})
-    ActiveSupport::Notifications.instrument name, data do 
+    ActiveSupport::Notifications.instrument name, data do
       # nothing
     end
   end

--- a/test/unit/adapters/librato_adapter_test.rb
+++ b/test/unit/adapters/librato_adapter_test.rb
@@ -66,7 +66,7 @@ class LibratoAdapterTest < MiniTest::Unit::TestCase
     assert_requested expected_request
   end
 
-  def test_logging_gague_raises_an_exception
+  def test_logging_gauge_raises_an_exception
     stub_request(:post, %r{metrics}).to_return(:status => 500, :body => "message")
 
     assert_raises Harness::LoggingError do

--- a/test/unit/harness_test.rb
+++ b/test/unit/harness_test.rb
@@ -14,15 +14,21 @@ class HarnessModuleTest < MiniTest::Unit::TestCase
   end
 
   def test_can_set_the_queue_with_a_symbol
+    Harness.config.queue = :synchronous
+
+    assert_kind_of Harness::SynchronousQueue, Harness.config.queue
+  end
+
+  def test_can_set_the_queue_with_misspelled_symbol_for_backward_compat
     Harness.config.queue = :syncronous
 
-    assert_kind_of Harness::SyncronousQueue, Harness.config.queue
+    assert_kind_of Harness::SynchronousQueue, Harness.config.queue
   end
 
   def test_can_set_the_queue_with_a_class
-    Harness.config.queue = Harness::SyncronousQueue
+    Harness.config.queue = Harness::SynchronousQueue
 
-    assert_equal Harness::SyncronousQueue, Harness.config.queue
+    assert_equal Harness::SynchronousQueue, Harness.config.queue
   end
 
   def test_uses_method_missing_to_configure_adapters


### PR DESCRIPTION
- Cleaned up some doc misspellings
- Fixed spelling of SyncronousQueue -> SynchronousQueue, making sure the old spelling continues to work for the time being
- Documented ability to provide a value to a gauge
- Provided example of calling AS::Notifications.instrument without a block
