### PR TITLE
Integrations shouldn't be required with the gem.

### DIFF
--- a/lib/harness.rb
+++ b/lib/harness.rb
@@ -97,11 +97,6 @@ require 'harness/adapters/memory_adapter'
 require 'harness/adapters/null_adapter'
 require 'harness/adapters/statsd_adapter'
 
-require 'harness/integration/action_controller'
-require 'harness/integration/action_view'
-require 'harness/integration/action_mailer'
-require 'harness/integration/active_support'
-
 require 'harness/railtie' if defined?(Rails)
 
 require 'logger'

--- a/test/integration/integrations/active_support_test.rb
+++ b/test/integration/integrations/active_support_test.rb
@@ -33,6 +33,7 @@ class ActiveSupportIntegration < IntegrationTest
 
   private
   def instrument(event)
+    require 'harness/integration/active_support'
     ActiveSupport::Notifications.instrument "#{event}.active_support" do |*args|
       # nada
     end


### PR DESCRIPTION
Prior to this change, rails integrations were always active, regardless of app configuration, because they were required when the gem was required.
