### PR TITLE
Fix the railtie to set up the synchronous queue properly.

### DIFF
--- a/lib/harness.rb
+++ b/lib/harness.rb
@@ -34,9 +34,9 @@ module Harness
 
     def queue=(val)
       if val.is_a? Symbol
-        @queue= "Harness::#{val.to_s.camelize}Queue".constantize.new
+        @queue = "Harness::#{val.to_s.camelize}Queue".constantize.new
       else
-        @queue= val
+        @queue = val
       end
     end
 

--- a/lib/harness/railtie.rb
+++ b/lib/harness/railtie.rb
@@ -40,7 +40,7 @@ module Harness
     end
 
     initializer "harness.queue" do
-      Harness.config.queue = Harness::SynchronousQueue
+      Harness.config.queue = :synchronous
     end
 
     initializer "harness.queue.production" do |app|

--- a/test/integration/railtie_test.rb
+++ b/test/integration/railtie_test.rb
@@ -19,4 +19,8 @@ class RailtieTest < MiniTest::Unit::TestCase
     assert app.config.harness.instrument.action_view
     refute app.config.harness.instrument.active_support
   end
+
+  def test_configures_queue
+    assert_kind_of Harness::SynchronousQueue, app.config.harness.queue
+  end
 end

--- a/test/unit/harness_test.rb
+++ b/test/unit/harness_test.rb
@@ -7,10 +7,10 @@ class HarnessModuleTest < MiniTest::Unit::TestCase
     assert_kind_of Harness::MemoryAdapter, Harness.config.adapter
   end
 
-  def test_can_set_the_adapter_with_a_class
-    Harness.config.adapter = Harness::MemoryAdapter
+  def test_can_set_the_adapter_with_an_adapter_instance
+    Harness.config.adapter = Harness::MemoryAdapter.new
 
-    assert_equal Harness::MemoryAdapter, Harness.config.adapter
+    assert_kind_of Harness::MemoryAdapter, Harness.config.adapter
   end
 
   def test_can_set_the_queue_with_a_symbol
@@ -25,10 +25,10 @@ class HarnessModuleTest < MiniTest::Unit::TestCase
     assert_kind_of Harness::SynchronousQueue, Harness.config.queue
   end
 
-  def test_can_set_the_queue_with_a_class
-    Harness.config.queue = Harness::SynchronousQueue
+  def test_can_set_the_queue_with_a_queue_instance
+    Harness.config.queue = Harness::SynchronousQueue.new
 
-    assert_equal Harness::SynchronousQueue, Harness.config.queue
+    assert_kind_of Harness::SynchronousQueue, Harness.config.queue
   end
 
   def test_uses_method_missing_to_configure_adapters


### PR DESCRIPTION
The railtie sets up the queue as the SynchronousQueue class when it really needs to be an instance of the class. This commit fixes that, and updates tests to clarify this.
